### PR TITLE
Add build dependencies to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ First, install rizin and make sure the bap-frames submodule is up to date:
 git submodule update --init
 ```
 
+Afterwards install the build dependencies:
+```
+sudo apt install libprotobuf-dev protobuf-compile
+```
+
 Then:
 ```
 cd rz-tracetest


### PR DESCRIPTION
Without the dependencies `cmake` fails with:
```
CMake Error at /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:146 (message):
  Could NOT find Protobuf (missing: Protobuf_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:393 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.16/Modules/FindProtobuf.cmake:624 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  libtrace/CMakeLists.txt:18 (find_package)


-- Configuring incomplete, errors occurred!
See also "/home/user/git-repos/rz-tracetest/rz-tracetest/build/CMakeFiles/CMakeOutput.log".
See also "/home/user/git-repos/rz-tracetest/rz-tracetest/build/CMakeFiles/CMakeError.log".
```


