### PR TITLE
Add endianess flag for instruction bytes.

### DIFF
--- a/rz-tracetest/adapter.h
+++ b/rz-tracetest/adapter.h
@@ -71,6 +71,25 @@ class TraceAdapter
 		 * will be justified even if they are not recorded as post operands.
 		 */
 		virtual bool AllowNoOperandSameValueAssignment() const;
+
+		/**
+		 * \brief Get the is big endian flag
+		 * 
+		 * \return true Instruction bytes are in big endian.
+		 * \return false Instruction bytes are in little endian.
+		 */
+		bool get_is_big_endian() { return this->big_endian; }
+
+		/**
+		 * \brief Set the is big endian flag.
+		 * 
+		 * \param be True if instruction bytes are in big endian. False otherwise.
+		 */
+		void set_is_big_endian(bool be) { this->big_endian = be; }
+
+	private:
+		bool big_endian = false;
+		
 };
 
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch);

--- a/rz-tracetest/dump.cpp
+++ b/rz-tracetest/dump.cpp
@@ -18,6 +18,7 @@ void DumpTrace(SerializedTrace::TraceContainerReader &trace, ut64 offset, ut64 c
 		if (bits) {
 			rz_asm_set_bits(rzasm.get(), bits);
 		}
+		rz_asm_set_big_endian(rzasm.get(), adapter->get_is_big_endian());
 	}
 
 	printf("trace version: %" PFMT64u "\n", (ut64)trace.get_trace_version());
@@ -54,6 +55,7 @@ static void DumpStdFrame(const std_frame &frame, ut64 index, RzAsm *rzasm, Trace
 		if (bits) {
 			rz_asm_set_bits(rzasm, bits);
 		}
+		rz_asm_set_big_endian(rzasm, adapter->get_is_big_endian());
 		char *disasm = rz_asm_to_string(rzasm, frame.address(), (const ut8 *)frame.rawbytes().data(), frame.rawbytes().size());
 		printf("    %s", disasm ? rz_str_trim_tail(disasm) : "(null)");
 		rz_mem_free(disasm);

--- a/rz-tracetest/main.cpp
+++ b/rz-tracetest/main.cpp
@@ -11,6 +11,7 @@ static int help(bool verbose) {
 	if (verbose) {
 		printf(" -c [count]    number of frames to check, default: all\n");
 		printf(" -d            dump trace as text, but do not run or test anything\n");
+		printf(" -b            Interpret instruction bytes in the frames in big endian\n");
 		printf(" -e            fail early/stop at the first error\n");
 		printf(" -u            fail early/stop at the first unlifted execption\n");
 		printf(" -r            fail early/stop at the first runtime error\n");
@@ -33,11 +34,12 @@ int main(int argc, const char *argv[]) {
 	bool fail_unlifted = false;
 	bool fail_runtime = false;
 	bool fail_misexec = false;
+	bool big_endian = false;
 	int verbose = 0;
 	std::optional<std::regex> skip_re;
 
 	RzGetopt opt;
-	rz_getopt_init(&opt, argc, (const char **)argv, "hc:o:idvs:eurm");
+	rz_getopt_init(&opt, argc, (const char **)argv, "hc:o:idbvs:eurm");
 	int c;
 	while ((c = rz_getopt_next(&opt)) != -1) {
 		switch (c) {
@@ -51,6 +53,9 @@ int main(int argc, const char *argv[]) {
 			break;
 		case 'i':
 			invalid_op_quiet = true;
+			break;
+		case 'b':
+			big_endian = true;
 			break;
 		case 'd':
 			dump_only = true;
@@ -95,12 +100,13 @@ int main(int argc, const char *argv[]) {
 
 	SerializedTrace::TraceContainerReader trace(argv[opt.ind]);
 	auto adapter = SelectTraceAdapter(trace.get_arch());
+	if (!adapter) {
+		throw RizinException("Failed to match frame_architecture %d to TraceAdapter.\n", (int)trace.get_arch());
+	}
+	adapter.get()->set_is_big_endian(big_endian);
 	if (dump_only) {
 		DumpTrace(trace, offset, count, verbose, adapter.get());
 		return 0;
-	}
-	if (!adapter) {
-		throw RizinException("Failed to match frame_architecture %d to TraceAdapter.\n", (int)trace.get_arch());
 	}
 	RizinEmulator r(std::move(adapter));
 	trace.seek(offset);

--- a/rz-tracetest/rzemu.cpp
+++ b/rz-tracetest/rzemu.cpp
@@ -26,6 +26,7 @@ RizinEmulator::RizinEmulator(std::unique_ptr<TraceAdapter> adapter_arg) :
 	if (bits) {
 		rz_config_set_i(core->config, "asm.bits", bits);
 	}
+	rz_config_set_b(core->config, "cfg.bigendian", adapter->get_is_big_endian());
 	char *reg_profile = rz_analysis_get_reg_profile(core->analysis);
 	if (!reg_profile) {
 		throw RizinException("Failed to get reg profile.");


### PR DESCRIPTION
Adds a command line flag. Currently the instruction bytes are interpreted in little endian. The new `b` flag interprets them in big endian.

Please note that this is the lazy variant to implement it (time is scarce). The much nicer way would be to save this information in the BAP frames/trace header (see: comment in [frame_reade.ml](https://github.com/BinaryAnalysisPlatform/bap-frames/blob/1d8094584c9b63ec2daa0511a519ddd6d686d3dc/lib/frame_reader.ml#L55-L60)).