### PR TITLE
PPC trace adapter

### DIFF
--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -5,7 +5,7 @@
 
 #include <memory>
 
-static bool is_one_bit_flag(const std::string &tn) {
+static inline bool IsOneBitFlag(const std::string &tn) {
 	// PPC
 	if (tn == "ca" || tn == "ca32" || tn == "ov" || tn == "ov32" || tn == "so") {
 		return true;
@@ -256,7 +256,7 @@ class PPCTraceAdapter : public TraceAdapter {
 				rz_bv_fini(trace_val);
 				rz_bv_init(trace_val, 4);
 				rz_bv_set_from_ut64(trace_val, v);
-			} else if (is_one_bit_flag(tracename)) {
+			} else if (IsOneBitFlag(tracename)) {
 				bool set = !rz_bv_is_zero_vector(trace_val);
 				rz_bv_fini(trace_val);
 				rz_bv_init(trace_val, 1);

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -17,7 +17,14 @@ std::string TraceAdapter::RizinCPU() const {
 	return std::string();
 }
 
-int TraceAdapter::RizinBits(std::optional<std::string> mode, std::optional<uint64_t> mach) const {
+/**
+ * \brief Returns the bits for asm.bits.
+ *
+ * \param mode The frame mode from TraceContainerReader.
+ * \param machine The machine type from TraceContainerReader.
+ * \return int The architecture bits of the trace.
+ */
+int TraceAdapter::RizinBits(std::optional<std::string> mode, std::optional<uint64_t> machine) const {
 	return 0;
 }
 
@@ -123,7 +130,7 @@ class Arm32TraceAdapter : public TraceAdapter {
 	public:
 		std::string RizinArch() const override { return "arm"; }
 
-		int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> mach) const override {
+		int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> machine) const override {
 			return (mode && mode.value() == FRAME_MODE_ARM_T32) ? 16 : 32;
 		}
 
@@ -180,7 +187,7 @@ class Arm32TraceAdapter : public TraceAdapter {
 class Arm64TraceAdapter : public TraceAdapter {
 	public:
 		std::string RizinArch() const override { return "arm"; }
-		int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> mach) const override { return 64; }
+		int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> machine) const override { return 64; }
 
 		std::string TraceRegToRizin(const std::string &tracereg) const override {
 			if (tracereg == "R31") {
@@ -209,11 +216,11 @@ class PPCTraceAdapter : public TraceAdapter {
 	public:
 		std::string RizinArch() const override { return "ppc"; }
 
-		int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> mach) const override {
+		int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> machine) const override {
 			if (mode) {
 				return (mode.value() == FRAME_MODE_PPC64) ? 64 : 32;
 			}
-			return mach.value();
+			return machine.value();
 		}
 
 		bool IgnorePCMismatch(ut64 pc_actual, ut64 pc_expect) const override {

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -220,6 +220,12 @@ class PPCTraceAdapter : public TraceAdapter
 			std::transform(r.begin(), r.end(), r.begin(), ::tolower);
 			return r;
 		}
+		
+		void AdjustRegContentsFromTrace(const std::string &tracename, RzBitVector *trace_val, RzAnalysisOp *op) const override {
+			if (tracename.substr(0, 3) == "crf") {
+				trace_val->len = 4;
+			}
+		}
 };
 
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -21,6 +21,10 @@ int TraceAdapter::RizinBits(std::optional<std::string> mode, std::optional<uint6
 	return 0;
 }
 
+bool TraceAdapter::IgnoreUnknownReg(const std::string &rz_reg_name) const {
+	return false;
+}
+
 /**
  * \brief Converts the a register name from the trace to an equivalent register name in Rizin.
  * 
@@ -218,6 +222,10 @@ class PPCTraceAdapter : public TraceAdapter
 
 		bool IgnorePCMismatch(ut64 pc_actual, ut64 pc_expect) const override {
 			return false;
+		}
+
+		bool IgnoreUnknownReg(const std::string &rz_reg_name) const {
+			return rz_reg_name == "ca32" || rz_reg_name == "ov32";
 		}
 
 		std::string TraceRegToRizin(const std::string &tracereg) const override {

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -15,7 +15,7 @@ int TraceAdapter::RizinBits(std::optional<std::string> mode) const {
 
 /**
  * \brief Converts the a register name from the trace to an equivalent register name in Rizin.
- *
+ * 
  * \param tracereg The trace register name.
  * \return std::string The equivalent register name in Rizin.
  */
@@ -200,29 +200,13 @@ class PPCTraceAdapter : public TraceAdapter
 {
 	public:
 		std::string RizinArch() const override { return "ppc"; }
-		int RizinBits(std::optional<std::string> mode) const override { return 64; }
+		int RizinBits(std::optional<std::string> mode) const override {
+			return (mode && mode.value() == FRAME_MODE_PPC64) ? 64 : 32;
+		}
 
-		// std::string TraceRegToRizin(const std::string &tracereg) const override {
-		// 	if (tracereg == "R31") {
-		// 		return "lr";
-		// 	}
-		// 	if (tracereg.size() >= 1 && tracereg[0] == 'R') {
-		// 		return "x" + tracereg.substr(1);
-		// 	}
-		// 	std::string r = tracereg;
-		// 	std::transform(r.begin(), r.end(), r.begin(), ::tolower);
-		// 	return r;
-		// }
-
-		// void AdjustRegContentsFromTrace(const std::string &tracename, RzBitVector *trace_val, RzAnalysisOp *op) const override {
-		// 	if (tracename == "NF" || tracename == "ZF" || tracename == "CF" || tracename == "VF") {
-		// 		// flags in the trace have 32 bits, but they should just have 1
-		// 		bool set = !rz_bv_is_zero_vector(trace_val);
-		// 		rz_bv_fini(trace_val);
-		// 		rz_bv_init(trace_val, 1);
-		// 		rz_bv_set_from_ut64(trace_val, set ? 1 : 0);
-		// 	}
-		// }
+		bool IgnorePCMismatch(ut64 pc_actual, ut64 pc_expect) const override {
+			return false;
+		}
 };
 
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -17,7 +17,7 @@ std::string TraceAdapter::RizinCPU() const {
 	return std::string();
 }
 
-int TraceAdapter::RizinBits(std::optional<std::string> mode) const {
+int TraceAdapter::RizinBits(std::optional<std::string> mode, std::optional<uint64_t> mach) const {
 	return 0;
 }
 
@@ -121,7 +121,7 @@ class Arm32TraceAdapter : public TraceAdapter
 	public:
 		std::string RizinArch() const override { return "arm"; }
 
-		int RizinBits(std::optional<std::string> mode) const override {
+		int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> mach) const override {
 			return (mode && mode.value() == FRAME_MODE_ARM_T32) ? 16 : 32;
 		}
 
@@ -179,7 +179,7 @@ class Arm64TraceAdapter : public TraceAdapter
 {
 	public:
 		std::string RizinArch() const override { return "arm"; }
-		int RizinBits(std::optional<std::string> mode) const override { return 64; }
+		int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> mach) const override { return 64; }
 
 		std::string TraceRegToRizin(const std::string &tracereg) const override {
 			if (tracereg == "R31") {
@@ -209,8 +209,11 @@ class PPCTraceAdapter : public TraceAdapter
 	public:
 		std::string RizinArch() const override { return "ppc"; }
 
-		int RizinBits(std::optional<std::string> mode) const override {
-			return (mode && mode.value() == FRAME_MODE_PPC64) ? 64 : 32;
+		int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> mach) const override {
+			if (mode) {
+				return (mode.value() == FRAME_MODE_PPC64) ? 64 : 32;
+			}
+			return mach.value();
 		}
 
 		bool IgnorePCMismatch(ut64 pc_actual, ut64 pc_expect) const override {

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -13,14 +13,41 @@ int TraceAdapter::RizinBits(std::optional<std::string> mode) const {
 	return 0;
 }
 
+/**
+ * \brief Converts the a register name from the trace to an equivalent register name in Rizin.
+ *
+ * \param tracereg The trace register name.
+ * \return std::string The equivalent register name in Rizin.
+ */
 std::string TraceAdapter::TraceRegToRizin(const std::string &tracereg) const {
 	return tracereg;
 }
 
+/**
+ * \brief Manipulates the content of a register before it is compared to Rizin.
+ *
+ * \param tracename The register name in the trace.
+ * \param trace_val The register content to manipulate.
+ * \param op The RzAnalysisOp this register belongs to.
+ */
 void TraceAdapter::AdjustRegContentsFromTrace(const std::string &tracename, RzBitVector *trace_val, RzAnalysisOp *op) const {}
 
+/**
+ * \brief Manipulates the content of a register before before it is compared to the trace.
+ *
+ * \param tracename The register name in the trace.
+ * \param trace_val The register content to manipulate.
+ * \param op The RzAnalysisOp this register belongs to.
+ */
 void TraceAdapter::AdjustRegContentsFromRizin(const std::string &tracename, RzBitVector *rizin_val) const {}
 
+/**
+ * \brief Prints the register content with more details. Useful for printing fields in registers with their descriptions or names.
+ *
+ * \param tracename Register name in the trace.
+ * \param data The register content.
+ * \param bits_size Size of the register.
+ */
 void TraceAdapter::PrintRegisterDetails(const std::string &tracename, const std::string &data, size_t bits_size) const {}
 
 bool TraceAdapter::IgnorePCMismatch(ut64 pc_actual, ut64 pc_expect) const {

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -28,6 +28,13 @@ int TraceAdapter::RizinBits(std::optional<std::string> mode, std::optional<uint6
 	return 0;
 }
 
+/**
+ * \brief Returns if a given register name from the trace should be ignored if it isn't implemented in Rizin.
+ *
+ * \param rz_reg_name The trace register name.
+ * \return true The register, missing in Rizin, should be ignored.
+ * \return false Notify the user about the missing register in Rizin.
+ */
 bool TraceAdapter::IgnoreUnknownReg(const std::string &rz_reg_name) const {
 	return false;
 }

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -169,6 +169,35 @@ class Arm64TraceAdapter : public TraceAdapter
 		}
 };
 
+class PPCTraceAdapter : public TraceAdapter
+{
+	public:
+		std::string RizinArch() const override { return "ppc"; }
+		int RizinBits(std::optional<std::string> mode) const override { return 64; }
+
+		// std::string TraceRegToRizin(const std::string &tracereg) const override {
+		// 	if (tracereg == "R31") {
+		// 		return "lr";
+		// 	}
+		// 	if (tracereg.size() >= 1 && tracereg[0] == 'R') {
+		// 		return "x" + tracereg.substr(1);
+		// 	}
+		// 	std::string r = tracereg;
+		// 	std::transform(r.begin(), r.end(), r.begin(), ::tolower);
+		// 	return r;
+		// }
+
+		// void AdjustRegContentsFromTrace(const std::string &tracename, RzBitVector *trace_val, RzAnalysisOp *op) const override {
+		// 	if (tracename == "NF" || tracename == "ZF" || tracename == "CF" || tracename == "VF") {
+		// 		// flags in the trace have 32 bits, but they should just have 1
+		// 		bool set = !rz_bv_is_zero_vector(trace_val);
+		// 		rz_bv_fini(trace_val);
+		// 		rz_bv_init(trace_val, 1);
+		// 		rz_bv_set_from_ut64(trace_val, set ? 1 : 0);
+		// 	}
+		// }
+};
+
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {
 	switch (arch) {
 		case frame_arch_6502:
@@ -177,6 +206,8 @@ std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {
 			return std::unique_ptr<TraceAdapter>(new Arm32TraceAdapter());
 		case frame_arch_aarch64:
 			return std::unique_ptr<TraceAdapter>(new Arm64TraceAdapter());
+		case frame_arch_powerpc:
+			return std::unique_ptr<TraceAdapter>(new PPCTraceAdapter());
 		default:
 			return nullptr;
 	}

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -17,63 +17,22 @@ std::string TraceAdapter::RizinCPU() const {
 	return std::string();
 }
 
-/**
- * \brief Returns the bits for asm.bits.
- *
- * \param mode The frame mode from TraceContainerReader.
- * \param machine The machine type from TraceContainerReader.
- * \return int The architecture bits of the trace.
- */
 int TraceAdapter::RizinBits(std::optional<std::string> mode, std::optional<uint64_t> machine) const {
 	return 0;
 }
 
-/**
- * \brief Returns if a given register name from the trace should be ignored if it isn't implemented in Rizin.
- *
- * \param rz_reg_name The trace register name.
- * \return true The register, missing in Rizin, should be ignored.
- * \return false Notify the user about the missing register in Rizin.
- */
 bool TraceAdapter::IgnoreUnknownReg(const std::string &rz_reg_name) const {
 	return false;
 }
 
-/**
- * \brief Converts the a register name from the trace to an equivalent register name in Rizin.
- *
- * \param tracereg The trace register name.
- * \return std::string The equivalent register name in Rizin.
- */
 std::string TraceAdapter::TraceRegToRizin(const std::string &tracereg) const {
 	return tracereg;
 }
 
-/**
- * \brief Manipulates the content of a register before it is compared to Rizin.
- *
- * \param tracename The register name in the trace.
- * \param trace_val The register content to manipulate.
- * \param op The RzAnalysisOp this register belongs to.
- */
 void TraceAdapter::AdjustRegContentsFromTrace(const std::string &tracename, RzBitVector *trace_val, RzAnalysisOp *op) const {}
 
-/**
- * \brief Manipulates the content of a register before before it is compared to the trace.
- *
- * \param tracename The register name in the trace.
- * \param trace_val The register content to manipulate.
- * \param op The RzAnalysisOp this register belongs to.
- */
 void TraceAdapter::AdjustRegContentsFromRizin(const std::string &tracename, RzBitVector *rizin_val) const {}
 
-/**
- * \brief Prints the register content with more details. Useful for printing fields in registers with their descriptions or names.
- *
- * \param tracename Register name in the trace.
- * \param data The register content.
- * \param bits_size Size of the register.
- */
 void TraceAdapter::PrintRegisterDetails(const std::string &tracename, const std::string &data, size_t bits_size) const {}
 
 bool TraceAdapter::IgnorePCMismatch(ut64 pc_actual, ut64 pc_expect) const {

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -216,7 +216,9 @@ class PPCTraceAdapter : public TraceAdapter
 				.append(tracereg.substr(0, 2))
 				.append(tracereg.substr(3, 1));
 			}
-			return tracereg;
+			std::string r = tracereg;
+			std::transform(r.begin(), r.end(), r.begin(), ::tolower);
+			return r;
 		}
 };
 

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -207,6 +207,17 @@ class PPCTraceAdapter : public TraceAdapter
 		bool IgnorePCMismatch(ut64 pc_actual, ut64 pc_expect) const override {
 			return false;
 		}
+
+                std::string
+                TraceRegToRizin(const std::string &tracereg) const override {
+                  if (tracereg.substr(0, 3) == "crf") {
+                    // crf0 -> cr0
+                    return std::string()
+                        .append(tracereg.substr(0, 2))
+                        .append(tracereg.substr(3, 1));
+                  }
+                  return tracereg;
+                }
 };
 
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -5,6 +5,14 @@
 
 #include <memory>
 
+static bool is_one_bit_flag(const std::string &tn) {
+	// PPC
+	if (tn == "ca" || tn == "ca32" || tn == "ov" || tn == "ov32" || tn == "so") {
+		return true;
+	}
+	return false;
+}
+
 std::string TraceAdapter::RizinCPU() const {
 	return std::string();
 }
@@ -223,7 +231,15 @@ class PPCTraceAdapter : public TraceAdapter
 		
 		void AdjustRegContentsFromTrace(const std::string &tracename, RzBitVector *trace_val, RzAnalysisOp *op) const override {
 			if (tracename.substr(0, 3) == "crf") {
-				trace_val->len = 4;
+				ut8 v = rz_bv_to_ut8(trace_val);
+				rz_bv_fini(trace_val);
+				rz_bv_init(trace_val, 4);
+				rz_bv_set_from_ut64(trace_val, v);
+			} else if (is_one_bit_flag(tracename)) {
+				bool set = !rz_bv_is_zero_vector(trace_val);
+				rz_bv_fini(trace_val);
+				rz_bv_init(trace_val, 1);
+				rz_bv_set_from_ut64(trace_val, set ? 1 : 0);
 			}
 		}
 };

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -230,7 +230,7 @@ class PPCTraceAdapter : public TraceAdapter {
 				ut64 v = rz_bv_to_ut64(trace_val);
 				rz_bv_fini(trace_val);
 				rz_bv_init(trace_val, 64);
-				ut64 r = v & 0xfffffffffff3ffff;
+				ut64 r = v & PPC_XER_ISA2_BITS_MASK;
 				rz_bv_set_from_ut64(trace_val, r);
 			}
 		}
@@ -243,7 +243,7 @@ class PPCTraceAdapter : public TraceAdapter {
 				ut64 v = rz_bv_to_ut64(rizin_val);
 				rz_bv_fini(rizin_val);
 				rz_bv_init(rizin_val, 64);
-				ut64 r = v & 0xfffffffffff3ffff;
+				ut64 r = v & PPC_XER_ISA2_BITS_MASK;
 				rz_bv_set_from_ut64(rizin_val, r);
 			}
 		}

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -27,7 +27,7 @@ bool TraceAdapter::IgnoreUnknownReg(const std::string &rz_reg_name) const {
 
 /**
  * \brief Converts the a register name from the trace to an equivalent register name in Rizin.
- * 
+ *
  * \param tracereg The trace register name.
  * \return std::string The equivalent register name in Rizin.
  */
@@ -70,8 +70,7 @@ bool TraceAdapter::AllowNoOperandSameValueAssignment() const {
 	return false;
 }
 
-class VICETraceAdapter : public TraceAdapter
-{
+class VICETraceAdapter : public TraceAdapter {
 	public:
 		std::string RizinArch() const override { return "6502"; }
 
@@ -120,8 +119,7 @@ class VICETraceAdapter : public TraceAdapter
 		}
 };
 
-class Arm32TraceAdapter : public TraceAdapter
-{
+class Arm32TraceAdapter : public TraceAdapter {
 	public:
 		std::string RizinArch() const override { return "arm"; }
 
@@ -179,8 +177,7 @@ class Arm32TraceAdapter : public TraceAdapter
 		}
 };
 
-class Arm64TraceAdapter : public TraceAdapter
-{
+class Arm64TraceAdapter : public TraceAdapter {
 	public:
 		std::string RizinArch() const override { return "arm"; }
 		int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> mach) const override { return 64; }
@@ -208,8 +205,7 @@ class Arm64TraceAdapter : public TraceAdapter
 		}
 };
 
-class PPCTraceAdapter : public TraceAdapter
-{
+class PPCTraceAdapter : public TraceAdapter {
 	public:
 		std::string RizinArch() const override { return "ppc"; }
 
@@ -230,16 +226,16 @@ class PPCTraceAdapter : public TraceAdapter
 
 		std::string TraceRegToRizin(const std::string &tracereg) const override {
 			if (tracereg.substr(0, 3) == "crf") {
-			// crf0 -> cr0
-			return std::string()
-				.append(tracereg.substr(0, 2))
-				.append(tracereg.substr(3, 1));
+				// crf0 -> cr0
+				return std::string()
+					.append(tracereg.substr(0, 2))
+					.append(tracereg.substr(3, 1));
 			}
 			std::string r = tracereg;
 			std::transform(r.begin(), r.end(), r.begin(), ::tolower);
 			return r;
 		}
-		
+
 		void AdjustRegContentsFromTrace(const std::string &tracename, RzBitVector *trace_val, RzAnalysisOp *op) const override {
 			if (tracename.substr(0, 3) == "crf") {
 				ut8 v = rz_bv_to_ut8(trace_val);
@@ -251,46 +247,46 @@ class PPCTraceAdapter : public TraceAdapter
 				rz_bv_fini(trace_val);
 				rz_bv_init(trace_val, 1);
 				rz_bv_set_from_ut64(trace_val, set ? 1 : 0);
-                        } else if (tracename == "VRSAVE") {
-                          ut64 v = rz_bv_to_ut64(trace_val);
-                          rz_bv_fini(trace_val);
-                          rz_bv_init(trace_val, 32);
-                          rz_bv_set_from_ut64(trace_val, v);
-                        } else if (tracename == "XER") {
-                          // Remove ca32 and ov32 bits
-                          ut64 v = rz_bv_to_ut64(trace_val);
-                          rz_bv_fini(trace_val);
-                          rz_bv_init(trace_val, 64);
-                          ut64 r = v & 0xfffffffffff3ffff;
-                          rz_bv_set_from_ut64(trace_val, r);
-                        }
-                }
+			} else if (tracename == "VRSAVE") {
+				ut64 v = rz_bv_to_ut64(trace_val);
+				rz_bv_fini(trace_val);
+				rz_bv_init(trace_val, 32);
+				rz_bv_set_from_ut64(trace_val, v);
+			} else if (tracename == "XER") {
+				// Remove ca32 and ov32 bits
+				ut64 v = rz_bv_to_ut64(trace_val);
+				rz_bv_fini(trace_val);
+				rz_bv_init(trace_val, 64);
+				ut64 r = v & 0xfffffffffff3ffff;
+				rz_bv_set_from_ut64(trace_val, r);
+			}
+		}
 
-                void AdjustRegContentsFromRizin(
-                    const std::string &tracename,
-                    RzBitVector *rizin_val) const override {
-                  if (tracename == "XER") {
-                    // Remove ca32 and ov32 bits
-                    ut64 v = rz_bv_to_ut64(rizin_val);
-                    rz_bv_fini(rizin_val);
-                    rz_bv_init(rizin_val, 64);
-                    ut64 r = v & 0xfffffffffff3ffff;
-                    rz_bv_set_from_ut64(rizin_val, r);
-                  }
-                }
+		void AdjustRegContentsFromRizin(
+			const std::string &tracename,
+			RzBitVector *rizin_val) const override {
+			if (tracename == "XER") {
+				// Remove ca32 and ov32 bits
+				ut64 v = rz_bv_to_ut64(rizin_val);
+				rz_bv_fini(rizin_val);
+				rz_bv_init(rizin_val, 64);
+				ut64 r = v & 0xfffffffffff3ffff;
+				rz_bv_set_from_ut64(rizin_val, r);
+			}
+		}
 };
 
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {
 	switch (arch) {
-		case frame_arch_6502:
-			return std::unique_ptr<TraceAdapter>(new VICETraceAdapter());
-		case frame_arch_arm:
-			return std::unique_ptr<TraceAdapter>(new Arm32TraceAdapter());
-		case frame_arch_aarch64:
-			return std::unique_ptr<TraceAdapter>(new Arm64TraceAdapter());
-		case frame_arch_powerpc:
-			return std::unique_ptr<TraceAdapter>(new PPCTraceAdapter());
-		default:
-			return nullptr;
+	case frame_arch_6502:
+		return std::unique_ptr<TraceAdapter>(new VICETraceAdapter());
+	case frame_arch_arm:
+		return std::unique_ptr<TraceAdapter>(new Arm32TraceAdapter());
+	case frame_arch_aarch64:
+		return std::unique_ptr<TraceAdapter>(new Arm64TraceAdapter());
+	case frame_arch_powerpc:
+		return std::unique_ptr<TraceAdapter>(new PPCTraceAdapter());
+	default:
+		return nullptr;
 	}
 }

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -243,8 +243,33 @@ class PPCTraceAdapter : public TraceAdapter
 				rz_bv_fini(trace_val);
 				rz_bv_init(trace_val, 1);
 				rz_bv_set_from_ut64(trace_val, set ? 1 : 0);
-			}
-		}
+                        } else if (tracename == "VRSAVE") {
+                          ut64 v = rz_bv_to_ut64(trace_val);
+                          rz_bv_fini(trace_val);
+                          rz_bv_init(trace_val, 32);
+                          rz_bv_set_from_ut64(trace_val, v);
+                        } else if (tracename == "XER") {
+                          // Remove ca32 and ov32 bits
+                          ut64 v = rz_bv_to_ut64(trace_val);
+                          rz_bv_fini(trace_val);
+                          rz_bv_init(trace_val, 64);
+                          ut64 r = v & 0xfffffffffff3ffff;
+                          rz_bv_set_from_ut64(trace_val, r);
+                        }
+                }
+
+                void AdjustRegContentsFromRizin(
+                    const std::string &tracename,
+                    RzBitVector *rizin_val) const override {
+                  if (tracename == "XER") {
+                    // Remove ca32 and ov32 bits
+                    ut64 v = rz_bv_to_ut64(rizin_val);
+                    rz_bv_fini(rizin_val);
+                    rz_bv_init(rizin_val, 64);
+                    ut64 r = v & 0xfffffffffff3ffff;
+                    rz_bv_set_from_ut64(rizin_val, r);
+                  }
+                }
 };
 
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -200,6 +200,7 @@ class PPCTraceAdapter : public TraceAdapter
 {
 	public:
 		std::string RizinArch() const override { return "ppc"; }
+
 		int RizinBits(std::optional<std::string> mode) const override {
 			return (mode && mode.value() == FRAME_MODE_PPC64) ? 64 : 32;
 		}
@@ -208,16 +209,15 @@ class PPCTraceAdapter : public TraceAdapter
 			return false;
 		}
 
-                std::string
-                TraceRegToRizin(const std::string &tracereg) const override {
-                  if (tracereg.substr(0, 3) == "crf") {
-                    // crf0 -> cr0
-                    return std::string()
-                        .append(tracereg.substr(0, 2))
-                        .append(tracereg.substr(3, 1));
-                  }
-                  return tracereg;
-                }
+		std::string TraceRegToRizin(const std::string &tracereg) const override {
+			if (tracereg.substr(0, 3) == "crf") {
+			// crf0 -> cr0
+			return std::string()
+				.append(tracereg.substr(0, 2))
+				.append(tracereg.substr(3, 1));
+			}
+			return tracereg;
+		}
 };
 
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {

--- a/rz-tracetest/adapter.h
+++ b/rz-tracetest/adapter.h
@@ -12,6 +12,9 @@
 #include <string>
 #include <optional>
 
+// Mask to exclude ISA3 flags (ca32, ov32).
+#define PPC_XER_ISA2_BITS_MASK 0xfffffffffff3ffff
+
 /*
  * Interface for any arch/source/... specific adjustments
  */

--- a/rz-tracetest/adapter.h
+++ b/rz-tracetest/adapter.h
@@ -30,32 +30,50 @@ class TraceAdapter {
 		virtual std::string RizinCPU() const;
 
 		/**
-		 * value for asm.bits
+		 * \brief Returns the bits for asm.bits.
+		 *
+		 * \param mode The frame mode from TraceContainerReader.
+		 * \param machine The machine type from TraceContainerReader.
+		 * \return int The architecture bits of the trace.
 		 */
 		virtual int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> machine) const;
 
 		/**
-		 * Get the name of the register in RzReg for a reg name given by the trace.
+		 * \brief Get the name of the register in RzReg for a reg name given by the trace.
 		 * May return an empty string to indicate that the trace register does not exist in rizin and should be ignored.
+		 *
+		 * \param tracereg The trace register name.
+		 * \return std::string The equivalent register name in Rizin.
 		 */
 		virtual std::string TraceRegToRizin(const std::string &tracereg) const;
 
 		/**
-		 * Edit the contents of a register from the trace before comparison or before applying to RzReg
+		 * \brief Edit the contents of a register from the trace before comparison or before applying to RzReg
 		 * This is useful e.g. for masking out information that is unsupported by rizin.
-		 * \p op given only when checking post-operands (otherwise null), to mask out anything op-dependent
+		 *
+		 * \param tracename The register name in the trace.
+		 * \param trace_val The register content to manipulate.
+		 * \param op given only when checking post-operands (otherwise null), to mask out anything op-dependent
 		 */
 		virtual void AdjustRegContentsFromTrace(const std::string &tracename, RzBitVector *trace_val, RzAnalysisOp *op = nullptr) const;
 
 		/**
-		 * Edit the contents of a register from RzReg before comparison
+		 * \brief Edit the contents of a register from RzReg before comparison
 		 * This is useful e.g. for masking out information that is unsupported by the trace.
+		 *
+		 * \param tracename The register name in the trace.
+		 * \param trace_val The register content to manipulate.
+		 * \param op The RzAnalysisOp this register belongs to.
 		 */
 		virtual void AdjustRegContentsFromRizin(const std::string &tracename, RzBitVector *rizin_val) const;
 
 		/**
-		 * Print additional arch-specific info about the register contents to stdout
+		 * \brief Print additional arch-specific info about the register contents to stdout
 		 * This can be used for example to expand the individual flag bits of a status register.
+		 *
+		 * \param tracename Register name in the trace.
+		 * \param data The register content.
+		 * \param bits_size Size of the register.
 		 */
 		virtual void PrintRegisterDetails(const std::string &tracename, const std::string &data, size_t bits_size) const;
 
@@ -65,8 +83,11 @@ class TraceAdapter {
 		virtual bool IgnorePCMismatch(ut64 pc_actual, ut64 pc_expect) const;
 
 		/**
-		 * Return true if the given reg name is not implemnted in Rizin
-		 * on purpose and can be ignored.
+		 * \brief Returns if a given register name from the trace should be ignored if it isn't implemented in Rizin.
+		 *
+		 * \param rz_reg_name The trace register name.
+		 * \return true The register, missing in Rizin, should be ignored.
+		 * \return false Notify the user about the missing register in Rizin.
 		 */
 		virtual bool IgnoreUnknownReg(const std::string &rz_reg_name) const;
 

--- a/rz-tracetest/adapter.h
+++ b/rz-tracetest/adapter.h
@@ -82,18 +82,18 @@ class TraceAdapter {
 		 * \return true Instruction bytes are in big endian.
 		 * \return false Instruction bytes are in little endian.
 		 */
-		bool get_is_big_endian() { return this->big_endian; }
+		bool IsBigEndian() { return this->big_endian; }
 
 		/**
 		 * \brief Set the is big endian flag.
 		 *
 		 * \param be True if instruction bytes are in big endian. False otherwise.
 		 */
-		void set_is_big_endian(bool be) { this->big_endian = be; }
+		void SetIsBigEndian(bool be) { this->big_endian = be; }
 
-		void set_machine(uint64_t machine) { this->machine = machine; }
+		void SetMachine(uint64_t machine) { this->machine = machine; }
 
-		uint64_t get_machine() { return this->machine; }
+		uint64_t GetMachine() { return this->machine; }
 
 	private:
 		bool big_endian = false;

--- a/rz-tracetest/adapter.h
+++ b/rz-tracetest/adapter.h
@@ -67,6 +67,12 @@ class TraceAdapter
 		virtual bool IgnorePCMismatch(ut64 pc_actual, ut64 pc_expect) const;
 
 		/**
+		 * Return true if the given reg name is not implemnted in Rizin
+		 * on purpose and can be ignored.
+		 */
+		virtual bool IgnoreUnknownReg(const std::string &rz_reg_name) const;
+
+		/**
 		 * If this returns true, assignments to a variable with the same value as the variable had before
 		 * will be justified even if they are not recorded as post operands.
 		 */

--- a/rz-tracetest/adapter.h
+++ b/rz-tracetest/adapter.h
@@ -31,9 +31,8 @@ class TraceAdapter {
 
 		/**
 		 * value for asm.bits
-		 * \p encoding optional per-frame (CPU) mode
 		 */
-		virtual int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> mach) const;
+		virtual int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> machine) const;
 
 		/**
 		 * Get the name of the register in RzReg for a reg name given by the trace.
@@ -79,7 +78,7 @@ class TraceAdapter {
 
 		/**
 		 * \brief Get the is big endian flag
-		 * 
+		 *
 		 * \return true Instruction bytes are in big endian.
 		 * \return false Instruction bytes are in little endian.
 		 */
@@ -87,20 +86,18 @@ class TraceAdapter {
 
 		/**
 		 * \brief Set the is big endian flag.
-		 * 
+		 *
 		 * \param be True if instruction bytes are in big endian. False otherwise.
 		 */
 		void set_is_big_endian(bool be) { this->big_endian = be; }
 
+		void set_machine(uint64_t machine) { this->machine = machine; }
 
-		void set_mach(uint64_t mach) { this->mach = mach; }
-
-		uint64_t get_mach() { return this->mach; }
+		uint64_t get_machine() { return this->machine; }
 
 	private:
 		bool big_endian = false;
-		uint64_t mach = 0;
-		
+		uint64_t machine = 0;
 };
 
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch);

--- a/rz-tracetest/adapter.h
+++ b/rz-tracetest/adapter.h
@@ -71,6 +71,25 @@ class TraceAdapter
 		 * will be justified even if they are not recorded as post operands.
 		 */
 		virtual bool AllowNoOperandSameValueAssignment() const;
+
+		/**
+		 * \brief Get the is big endian flag
+		 * 
+		 * \return true Instruction bytes are in big endian.
+		 * \return false Instruction bytes are in little endian.
+		 */
+		bool get_is_big_endian() { return this->big_endian; }
+
+		/**
+		 * \brief Set the is big endian flag.
+		 * 
+		 * \param be True if instruction bytes are in big endian. False otherwise.
+		 */
+		void set_is_big_endian(bool be) { this->big_endian = be; }
+
+	private:
+		bool big_endian = false;
+		
 };
 
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch);

--- a/rz-tracetest/adapter.h
+++ b/rz-tracetest/adapter.h
@@ -34,7 +34,7 @@ class TraceAdapter
 		 * value for asm.bits
 		 * \p encoding optional per-frame (CPU) mode
 		 */
-		virtual int RizinBits(std::optional<std::string> mode) const;
+		virtual int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> mach) const;
 
 		/**
 		 * Get the name of the register in RzReg for a reg name given by the trace.
@@ -87,8 +87,14 @@ class TraceAdapter
 		 */
 		void set_is_big_endian(bool be) { this->big_endian = be; }
 
+
+		void set_mach(uint64_t mach) { this->mach = mach; }
+
+		uint64_t get_mach() { return this->mach; }
+
 	private:
 		bool big_endian = false;
+		uint64_t mach = 0;
 		
 };
 

--- a/rz-tracetest/dump.cpp
+++ b/rz-tracetest/dump.cpp
@@ -23,7 +23,7 @@ void DumpTrace(SerializedTrace::TraceContainerReader &trace, ut64 offset, ut64 c
 
 	printf("trace version: %" PFMT64u "\n", (ut64)trace.get_trace_version());
 	printf("arch: %" PFMT64u "\n", (ut64)trace.get_arch());
-	printf("mach: %" PFMT64u "\n", (ut64)trace.GetMachine());
+	printf("mach: %" PFMT64u "\n", (ut64)trace.get_machine());
 	printf("number of frames: %" PFMT64u "\n", (ut64)trace.get_num_frames());
 	const meta_frame *meta = trace.get_meta();
 	printf("META:\n%s\n======================================\n\n", meta->DebugString().c_str());

--- a/rz-tracetest/dump.cpp
+++ b/rz-tracetest/dump.cpp
@@ -32,7 +32,7 @@ void DumpTrace(SerializedTrace::TraceContainerReader &trace, ut64 offset, ut64 c
 		rzasm.reset(rz_asm_new());
 		rz_asm_use(rzasm.get(), adapter->RizinArch().c_str());
 		rz_asm_set_cpu(rzasm.get(), adapter->RizinCPU().c_str());
-		int bits = adapter->RizinBits(std::nullopt);
+		int bits = adapter->RizinBits(std::nullopt, adapter->get_mach());
 		if (bits) {
 			rz_asm_set_bits(rzasm.get(), bits);
 		}
@@ -69,7 +69,7 @@ static void DumpStdFrame(const std_frame &frame, ut64 index, RzAsm *rzasm, Trace
 	char *hex = rz_hex_bin2strdup((const ut8 *)frame.rawbytes().data(), frame.rawbytes().size());
 	printf(Color_BCYAN "-- %5" PFMT64u "    0x%" PFMT64x "    %s", index, (ut64)frame.address(), hex);
 	if (rzasm) {
-		int bits = adapter->RizinBits(frame.has_mode() ? std::make_optional(frame.mode()) : std::nullopt);
+		int bits = adapter->RizinBits(frame.has_mode() ? std::make_optional(frame.mode()) : std::nullopt, adapter->get_mach());
 		if (bits) {
 			rz_asm_set_bits(rzasm, bits);
 		}

--- a/rz-tracetest/dump.cpp
+++ b/rz-tracetest/dump.cpp
@@ -14,7 +14,7 @@ void DumpTrace(SerializedTrace::TraceContainerReader &trace, ut64 offset, ut64 c
 		rzasm.reset(rz_asm_new());
 		rz_asm_use(rzasm.get(), adapter->RizinArch().c_str());
 		rz_asm_set_cpu(rzasm.get(), adapter->RizinCPU().c_str());
-		int bits = adapter->RizinBits(std::nullopt, adapter->get_mach());
+		int bits = adapter->RizinBits(std::nullopt, adapter->get_machine());
 		if (bits) {
 			rz_asm_set_bits(rzasm.get(), bits);
 		}
@@ -51,7 +51,7 @@ static void DumpStdFrame(const std_frame &frame, ut64 index, RzAsm *rzasm, Trace
 	char *hex = rz_hex_bin2strdup((const ut8 *)frame.rawbytes().data(), frame.rawbytes().size());
 	printf(Color_BCYAN "-- %5" PFMT64u "    0x%" PFMT64x "    %s", index, (ut64)frame.address(), hex);
 	if (rzasm) {
-		int bits = adapter->RizinBits(frame.has_mode() ? std::make_optional(frame.mode()) : std::nullopt, adapter->get_mach());
+		int bits = adapter->RizinBits(frame.has_mode() ? std::make_optional(frame.mode()) : std::nullopt, adapter->get_machine());
 		if (bits) {
 			rz_asm_set_bits(rzasm, bits);
 		}

--- a/rz-tracetest/dump.cpp
+++ b/rz-tracetest/dump.cpp
@@ -6,6 +6,24 @@
 
 #include <rz_asm.h>
 
+/**
+ * \brief Returns a vector which holds the memory data from a frame.
+ * If \p big_endian_arch is true the bytes in the vector are in big endian.
+ * 
+ * \param data_ptr Pointer to the frame data.
+ * \param size Size of the frame data.
+ * \param big_endian_cpu True: The cpu stores data in big endian. False: In little endian.
+ * \return std::vector<ut8>*
+ */
+std::vector<ut8> ReadFrameMem(const char *data_ptr, ut32 size, bool big_endian_arch) {
+	std::vector<ut8> frame_mem(data_ptr, data_ptr + size);
+	if (big_endian_arch) {
+		// All numbers in the frames are in little endian.
+		std::reverse(frame_mem.begin(), frame_mem.end());
+	}
+	return frame_mem;
+}
+
 static void DumpStdFrame(const std_frame &frame, ut64 index, RzAsm *rzasm, TraceAdapter *adapter);
 
 void DumpTrace(SerializedTrace::TraceContainerReader &trace, ut64 offset, ut64 count, int verbose, TraceAdapter *adapter) {
@@ -64,12 +82,12 @@ static void DumpStdFrame(const std_frame &frame, ut64 index, RzAsm *rzasm, Trace
 	if (frame.has_mode()) {
 		printf("  MODE: %s\n", frame.mode().c_str());
 	}
-	DumpOperandList("  PRE  ", frame.operand_pre_list(), [](const operand_info &, size_t){});
-	DumpOperandList("  POST ", frame.operand_post_list(), [](const operand_info &, size_t){});
+	DumpOperandList("  PRE  ", frame.operand_pre_list(), [](const operand_info &, size_t){}, adapter->get_is_big_endian());
+	DumpOperandList("  POST ", frame.operand_post_list(), [](const operand_info &, size_t){}, adapter->get_is_big_endian());
 	rz_mem_free(hex);
 }
 
-void DumpOperandList(const char *prefix, const operand_value_list &operands, std::function<void(const operand_info &, size_t)> print_detail) {
+void DumpOperandList(const char *prefix, const operand_value_list &operands, std::function<void(const operand_info &, size_t)> print_detail, bool big_endian_cpu) {
 	for (const auto &o : operands.elem()) {
 		size_t real_bits = OperandSizeBits(o);
 		if (o.operand_info_specific().has_reg_operand()) {
@@ -81,7 +99,8 @@ void DumpOperandList(const char *prefix, const operand_value_list &operands, std
 			rz_mem_free(ts);
 		} else if (o.operand_info_specific().has_mem_operand()) {
 			const auto &mo = o.operand_info_specific().mem_operand();
-			char *hex = rz_hex_bin2strdup((const ut8 *)o.value().data(), o.value().size());
+			ut32 size = o.value().size();
+			char *hex = rz_hex_bin2strdup(ReadFrameMem(o.value().data(), size, big_endian_cpu).data(), size);
 			printf("%s[0x%04" PFMT64x "] = %s\n", prefix, (ut64)mo.address(), hex);
 		}
 		print_detail(o, real_bits);

--- a/rz-tracetest/dump.cpp
+++ b/rz-tracetest/dump.cpp
@@ -14,16 +14,16 @@ void DumpTrace(SerializedTrace::TraceContainerReader &trace, ut64 offset, ut64 c
 		rzasm.reset(rz_asm_new());
 		rz_asm_use(rzasm.get(), adapter->RizinArch().c_str());
 		rz_asm_set_cpu(rzasm.get(), adapter->RizinCPU().c_str());
-		int bits = adapter->RizinBits(std::nullopt, adapter->get_machine());
+		int bits = adapter->RizinBits(std::nullopt, adapter->GetMachine());
 		if (bits) {
 			rz_asm_set_bits(rzasm.get(), bits);
 		}
-		rz_asm_set_big_endian(rzasm.get(), adapter->get_is_big_endian());
+		rz_asm_set_big_endian(rzasm.get(), adapter->IsBigEndian());
 	}
 
 	printf("trace version: %" PFMT64u "\n", (ut64)trace.get_trace_version());
 	printf("arch: %" PFMT64u "\n", (ut64)trace.get_arch());
-	printf("mach: %" PFMT64u "\n", (ut64)trace.get_machine());
+	printf("mach: %" PFMT64u "\n", (ut64)trace.GetMachine());
 	printf("number of frames: %" PFMT64u "\n", (ut64)trace.get_num_frames());
 	const meta_frame *meta = trace.get_meta();
 	printf("META:\n%s\n======================================\n\n", meta->DebugString().c_str());
@@ -51,11 +51,11 @@ static void DumpStdFrame(const std_frame &frame, ut64 index, RzAsm *rzasm, Trace
 	char *hex = rz_hex_bin2strdup((const ut8 *)frame.rawbytes().data(), frame.rawbytes().size());
 	printf(Color_BCYAN "-- %5" PFMT64u "    0x%" PFMT64x "    %s", index, (ut64)frame.address(), hex);
 	if (rzasm) {
-		int bits = adapter->RizinBits(frame.has_mode() ? std::make_optional(frame.mode()) : std::nullopt, adapter->get_machine());
+		int bits = adapter->RizinBits(frame.has_mode() ? std::make_optional(frame.mode()) : std::nullopt, adapter->GetMachine());
 		if (bits) {
 			rz_asm_set_bits(rzasm, bits);
 		}
-		rz_asm_set_big_endian(rzasm, adapter->get_is_big_endian());
+		rz_asm_set_big_endian(rzasm, adapter->IsBigEndian());
 		char *disasm = rz_asm_to_string(rzasm, frame.address(), (const ut8 *)frame.rawbytes().data(), frame.rawbytes().size());
 		printf("    %s", disasm ? rz_str_trim_tail(disasm) : "(null)");
 		rz_mem_free(disasm);

--- a/rz-tracetest/dump.cpp
+++ b/rz-tracetest/dump.cpp
@@ -18,6 +18,7 @@ void DumpTrace(SerializedTrace::TraceContainerReader &trace, ut64 offset, ut64 c
 		if (bits) {
 			rz_asm_set_bits(rzasm.get(), bits);
 		}
+		rz_asm_set_big_endian(rzasm.get(), adapter->get_is_big_endian());
 	}
 
 	printf("trace version: %" PFMT64u "\n", (ut64)trace.get_trace_version());
@@ -54,6 +55,7 @@ static void DumpStdFrame(const std_frame &frame, ut64 index, RzAsm *rzasm, Trace
 		if (bits) {
 			rz_asm_set_bits(rzasm, bits);
 		}
+		rz_asm_set_big_endian(rzasm, adapter->get_is_big_endian());
 		char *disasm = rz_asm_to_string(rzasm, frame.address(), (const ut8 *)frame.rawbytes().data(), frame.rawbytes().size());
 		printf("    %s", disasm ? rz_str_trim_tail(disasm) : "(null)");
 		rz_mem_free(disasm);

--- a/rz-tracetest/dump.h
+++ b/rz-tracetest/dump.h
@@ -10,7 +10,6 @@
 #include <rz_util.h>
 
 void DumpTrace(SerializedTrace::TraceContainerReader &trace, ut64 offset, ut64 count, int verbose, TraceAdapter *adapter);
-void DumpOperandList(const char *prefix, const operand_value_list &operands, std::function<void(const operand_info &, size_t)> print_detail, bool big_endian_cpu);
-std::vector<ut8> ReadFrameMem(const char *data_ptr, ut32 size, bool big_endian_arch);
+void DumpOperandList(const char *prefix, const operand_value_list &operands, std::function<void(const operand_info &, size_t)> print_detail);
 
 #endif

--- a/rz-tracetest/dump.h
+++ b/rz-tracetest/dump.h
@@ -10,6 +10,7 @@
 #include <rz_util.h>
 
 void DumpTrace(SerializedTrace::TraceContainerReader &trace, ut64 offset, ut64 count, int verbose, TraceAdapter *adapter);
-void DumpOperandList(const char *prefix, const operand_value_list &operands, std::function<void(const operand_info &, size_t)> print_detail);
+void DumpOperandList(const char *prefix, const operand_value_list &operands, std::function<void(const operand_info &, size_t)> print_detail, bool big_endian_cpu);
+std::vector<ut8> ReadFrameMem(const char *data_ptr, ut32 size, bool big_endian_arch);
 
 #endif

--- a/rz-tracetest/main.cpp
+++ b/rz-tracetest/main.cpp
@@ -39,6 +39,7 @@ int main(int argc, const char *argv[]) {
 	RzGetopt opt;
 	rz_getopt_init(&opt, argc, (const char **)argv, "hc:o:idvs:eurm");
 	int c;
+
 	while ((c = rz_getopt_next(&opt)) != -1) {
 		switch (c) {
 		case 'h':

--- a/rz-tracetest/main.cpp
+++ b/rz-tracetest/main.cpp
@@ -104,6 +104,7 @@ int main(int argc, const char *argv[]) {
 	if (!adapter) {
 		throw RizinException("Failed to match frame_architecture %d to TraceAdapter.\n", (int)trace.get_arch());
 	}
+	adapter->set_mach(trace.get_machine());
 	adapter.get()->set_is_big_endian(big_endian);
 	if (dump_only) {
 		DumpTrace(trace, offset, count, verbose, adapter.get());

--- a/rz-tracetest/main.cpp
+++ b/rz-tracetest/main.cpp
@@ -104,7 +104,7 @@ int main(int argc, const char *argv[]) {
 	if (!adapter) {
 		throw RizinException("Failed to match frame_architecture %d to TraceAdapter.\n", (int)trace.get_arch());
 	}
-	adapter->SetMachine(trace.GetMachine());
+	adapter->SetMachine(trace.get_machine());
 	adapter.get()->SetIsBigEndian(big_endian);
 	if (dump_only) {
 		DumpTrace(trace, offset, count, verbose, adapter.get());

--- a/rz-tracetest/main.cpp
+++ b/rz-tracetest/main.cpp
@@ -104,8 +104,8 @@ int main(int argc, const char *argv[]) {
 	if (!adapter) {
 		throw RizinException("Failed to match frame_architecture %d to TraceAdapter.\n", (int)trace.get_arch());
 	}
-	adapter->set_machine(trace.get_machine());
-	adapter.get()->set_is_big_endian(big_endian);
+	adapter->SetMachine(trace.GetMachine());
+	adapter.get()->SetIsBigEndian(big_endian);
 	if (dump_only) {
 		DumpTrace(trace, offset, count, verbose, adapter.get());
 		return 0;

--- a/rz-tracetest/main.cpp
+++ b/rz-tracetest/main.cpp
@@ -11,6 +11,7 @@ static int help(bool verbose) {
 	if (verbose) {
 		printf(" -c [count]    number of frames to check, default: all\n");
 		printf(" -d            dump trace as text, but do not run or test anything\n");
+		printf(" -b            Interpret instruction bytes in the frames in big endian\n");
 		printf(" -e            fail early/stop at the first error\n");
 		printf(" -u            fail early/stop at the first unlifted execption\n");
 		printf(" -r            fail early/stop at the first runtime error\n");
@@ -33,11 +34,12 @@ int main(int argc, const char *argv[]) {
 	bool fail_unlifted = false;
 	bool fail_runtime = false;
 	bool fail_misexec = false;
+	bool big_endian = false;
 	int verbose = 0;
 	std::optional<std::regex> skip_re;
 
 	RzGetopt opt;
-	rz_getopt_init(&opt, argc, (const char **)argv, "hc:o:idvs:eurm");
+	rz_getopt_init(&opt, argc, (const char **)argv, "hc:o:idbvs:eurm");
 	int c;
 
 	while ((c = rz_getopt_next(&opt)) != -1) {
@@ -52,6 +54,9 @@ int main(int argc, const char *argv[]) {
 			break;
 		case 'i':
 			invalid_op_quiet = true;
+			break;
+		case 'b':
+			big_endian = true;
 			break;
 		case 'd':
 			dump_only = true;
@@ -96,12 +101,13 @@ int main(int argc, const char *argv[]) {
 
 	SerializedTrace::TraceContainerReader trace(argv[opt.ind]);
 	auto adapter = SelectTraceAdapter(trace.get_arch());
+	if (!adapter) {
+		throw RizinException("Failed to match frame_architecture %d to TraceAdapter.\n", (int)trace.get_arch());
+	}
+	adapter.get()->set_is_big_endian(big_endian);
 	if (dump_only) {
 		DumpTrace(trace, offset, count, verbose, adapter.get());
 		return 0;
-	}
-	if (!adapter) {
-		throw RizinException("Failed to match frame_architecture %d to TraceAdapter.\n", (int)trace.get_arch());
 	}
 	RizinEmulator r(std::move(adapter));
 	trace.seek(offset);

--- a/rz-tracetest/main.cpp
+++ b/rz-tracetest/main.cpp
@@ -104,7 +104,7 @@ int main(int argc, const char *argv[]) {
 	if (!adapter) {
 		throw RizinException("Failed to match frame_architecture %d to TraceAdapter.\n", (int)trace.get_arch());
 	}
-	adapter->set_mach(trace.get_machine());
+	adapter->set_machine(trace.get_machine());
 	adapter.get()->set_is_big_endian(big_endian);
 	if (dump_only) {
 		DumpTrace(trace, offset, count, verbose, adapter.get());

--- a/rz-tracetest/rzemu.cpp
+++ b/rz-tracetest/rzemu.cpp
@@ -22,7 +22,7 @@ RizinEmulator::RizinEmulator(std::unique_ptr<TraceAdapter> adapter_arg) :
 	if (!cpu.empty()) {
 		rz_config_set(core->config, "asm.cpu", cpu.c_str());
 	}
-	int bits = adapter->RizinBits(std::nullopt);
+	int bits = adapter->RizinBits(std::nullopt, adapter->get_mach());
 	if (bits) {
 		rz_config_set_i(core->config, "asm.bits", bits);
 	}
@@ -97,7 +97,7 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 	const std_frame &sf = f->std_frame();
 	const std::string &code = sf.rawbytes();
 
-	int need_bits = adapter->RizinBits(sf.has_mode() ? std::make_optional(sf.mode()) : std::nullopt);
+	int need_bits = adapter->RizinBits(sf.has_mode() ? std::make_optional(sf.mode()) : std::nullopt, adapter->get_mach());
 	if (need_bits && need_bits != core->rasm->bits) {
 		rz_config_set_i(core->config, "asm.bits", need_bits);
 	}

--- a/rz-tracetest/rzemu.cpp
+++ b/rz-tracetest/rzemu.cpp
@@ -284,7 +284,7 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 					return;
 				const auto &ro = o.operand_info_specific().reg_operand();
 				adapter->PrintRegisterDetails(ro.name(), o.value(), real_bits);
-			});
+			}, adapter->get_is_big_endian());
 		};
 		printf(Color_GREEN "PRE-OPERANDS:" Color_RESET "\n");
 		print_operands(sf.operand_pre_list());
@@ -361,9 +361,10 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 			ut64 size = MemOperandSizeBytes(o);
 			std::vector<ut8> actual(size);
 			rz_io_read_at(io, mo.address(), actual.data(), size);
-			if (memcmp(actual.data(), o.value().data(), size)) {
+			std::vector<ut8> frame_mem = ReadFrameMem(o.value().data(), size, adapter->get_is_big_endian());
+			if (memcmp(actual.data(), frame_mem.data(), size)) {
 				mismatched();
-				char *ts = rz_hex_bin2strdup((const ut8 *)o.value().data(), size);
+				char *ts = rz_hex_bin2strdup((const ut8 *)frame_mem.data(), size);
 				char *rs = rz_hex_bin2strdup(actual.data(), size);
 				printf(Color_RED "MISMATCH" Color_RESET " post memory:\n");
 				printf("  expected [0x%04" PFMT64x "] = %s\n", (ut64)mo.address(), ts);

--- a/rz-tracetest/rzemu.cpp
+++ b/rz-tracetest/rzemu.cpp
@@ -22,11 +22,11 @@ RizinEmulator::RizinEmulator(std::unique_ptr<TraceAdapter> adapter_arg)
 	if (!cpu.empty()) {
 		rz_config_set(core->config, "asm.cpu", cpu.c_str());
 	}
-	int bits = adapter->RizinBits(std::nullopt, adapter->get_machine());
+	int bits = adapter->RizinBits(std::nullopt, adapter->GetMachine());
 	if (bits) {
 		rz_config_set_i(core->config, "asm.bits", bits);
 	}
-	rz_config_set_b(core->config, "cfg.bigendian", adapter->get_is_big_endian());
+	rz_config_set_b(core->config, "cfg.bigendian", adapter->IsBigEndian());
 	char *reg_profile = rz_analysis_get_reg_profile(core->analysis);
 	if (!reg_profile) {
 		throw RizinException("Failed to get reg profile.");
@@ -97,7 +97,7 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 	const std_frame &sf = f->std_frame();
 	const std::string &code = sf.rawbytes();
 
-	int need_bits = adapter->RizinBits(sf.has_mode() ? std::make_optional(sf.mode()) : std::nullopt, adapter->get_machine());
+	int need_bits = adapter->RizinBits(sf.has_mode() ? std::make_optional(sf.mode()) : std::nullopt, adapter->GetMachine());
 	if (need_bits && need_bits != core->rasm->bits) {
 		rz_config_set_i(core->config, "asm.bits", need_bits);
 	}

--- a/rz-tracetest/rzemu.cpp
+++ b/rz-tracetest/rzemu.cpp
@@ -284,7 +284,7 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 					return;
 				const auto &ro = o.operand_info_specific().reg_operand();
 				adapter->PrintRegisterDetails(ro.name(), o.value(), real_bits);
-			}, adapter->get_is_big_endian());
+			});
 		};
 		printf(Color_GREEN "PRE-OPERANDS:" Color_RESET "\n");
 		print_operands(sf.operand_pre_list());
@@ -361,10 +361,9 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 			ut64 size = MemOperandSizeBytes(o);
 			std::vector<ut8> actual(size);
 			rz_io_read_at(io, mo.address(), actual.data(), size);
-			std::vector<ut8> frame_mem = ReadFrameMem(o.value().data(), size, adapter->get_is_big_endian());
-			if (memcmp(actual.data(), frame_mem.data(), size)) {
+			if (memcmp(actual.data(), o.value().data(), size)) {
 				mismatched();
-				char *ts = rz_hex_bin2strdup((const ut8 *)frame_mem.data(), size);
+				char *ts = rz_hex_bin2strdup((const ut8 *)o.value().data(), size);
 				char *rs = rz_hex_bin2strdup(actual.data(), size);
 				printf(Color_RED "MISMATCH" Color_RESET " post memory:\n");
 				printf("  expected [0x%04" PFMT64x "] = %s\n", (ut64)mo.address(), ts);

--- a/rz-tracetest/rzemu.cpp
+++ b/rz-tracetest/rzemu.cpp
@@ -333,7 +333,9 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 			}
 			RzRegItem *ri = rz_reg_get(reg.get(), rn.c_str(), RZ_REG_TYPE_ANY);
 			if (!ri) {
-				printf("Unknown reg: %s\n", ro.name().c_str());
+				if (!adapter->IgnoreUnknownReg(ro.name())) {
+					printf("Unknown reg: %s\n", ro.name().c_str());
+				}
 				continue;
 			}
 			RzBitVector *tbv = rz_bv_new_from_bytes_le((const ut8 *)o.value().data(), 0, RegOperandSizeBits(o));

--- a/rz-tracetest/rzemu.cpp
+++ b/rz-tracetest/rzemu.cpp
@@ -22,7 +22,7 @@ RizinEmulator::RizinEmulator(std::unique_ptr<TraceAdapter> adapter_arg)
 	if (!cpu.empty()) {
 		rz_config_set(core->config, "asm.cpu", cpu.c_str());
 	}
-	int bits = adapter->RizinBits(std::nullopt, adapter->get_mach());
+	int bits = adapter->RizinBits(std::nullopt, adapter->get_machine());
 	if (bits) {
 		rz_config_set_i(core->config, "asm.bits", bits);
 	}
@@ -97,7 +97,7 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 	const std_frame &sf = f->std_frame();
 	const std::string &code = sf.rawbytes();
 
-	int need_bits = adapter->RizinBits(sf.has_mode() ? std::make_optional(sf.mode()) : std::nullopt, adapter->get_mach());
+	int need_bits = adapter->RizinBits(sf.has_mode() ? std::make_optional(sf.mode()) : std::nullopt, adapter->get_machine());
 	if (need_bits && need_bits != core->rasm->bits) {
 		rz_config_set_i(core->config, "asm.bits", need_bits);
 	}

--- a/rz-tracetest/rzemu.cpp
+++ b/rz-tracetest/rzemu.cpp
@@ -26,6 +26,7 @@ RizinEmulator::RizinEmulator(std::unique_ptr<TraceAdapter> adapter_arg) :
 	if (bits) {
 		rz_config_set_i(core->config, "asm.bits", bits);
 	}
+	rz_config_set_b(core->config, "cfg.bigendian", adapter->get_is_big_endian());
 	char *reg_profile = rz_analysis_get_reg_profile(core->analysis);
 	if (!reg_profile) {
 		throw RizinException("Failed to get reg profile.");


### PR DESCRIPTION
This PR adds the PPC Trace adapter. With it it brings several other needed additions.

- PPC trace adapter
- Allow to pass `mach` as additional parameter to `RizinBits()`.
- Adds the command line option `-b`. If it is set `rz_asm` is initialized in big endian mode.