### PR TITLE
Add `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,27 @@
+Language: Cpp
+MaxEmptyLinesToKeep: 1
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInContainerLiterals: true
+BasedOnStyle: LLVM
+ContinuationIndentWidth: 8
+IndentCaseLabels: false
+IndentFunctionDeclarationAfterType: false
+IndentWidth: 8
+UseTab: ForContinuationAndIndentation
+ColumnLimit: 0
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: false
+AlignAfterOpenBracket: DontAlign
+AlignEscapedNewlines: DontAlign
+AlignConsecutiveMacros: true
+AlignTrailingComments: false
+AlignOperands: false
+Cpp11BracedListStyle: false
+ForEachMacros: ['rz_list_foreach', 'rz_list_foreach_safe', 'rz_pvector_foreach', 'rz_rbtree_foreach', 'rz_interval_tree_foreach', 'ls_foreach', 'rz_skiplist_foreach', 'graph_foreach_anode']
+SortIncludes: false
+IndentAccessModifiers: true

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -31,8 +31,7 @@ bool TraceAdapter::AllowNoOperandSameValueAssignment() const {
 	return false;
 }
 
-class VICETraceAdapter : public TraceAdapter
-{
+class VICETraceAdapter : public TraceAdapter {
 	public:
 		std::string RizinArch() const override { return "6502"; }
 
@@ -81,8 +80,7 @@ class VICETraceAdapter : public TraceAdapter
 		}
 };
 
-class Arm32TraceAdapter : public TraceAdapter
-{
+class Arm32TraceAdapter : public TraceAdapter {
 	public:
 		std::string RizinArch() const override { return "arm"; }
 
@@ -140,8 +138,7 @@ class Arm32TraceAdapter : public TraceAdapter
 		}
 };
 
-class Arm64TraceAdapter : public TraceAdapter
-{
+class Arm64TraceAdapter : public TraceAdapter {
 	public:
 		std::string RizinArch() const override { return "arm"; }
 		int RizinBits(std::optional<std::string> mode) const override { return 64; }
@@ -171,13 +168,13 @@ class Arm64TraceAdapter : public TraceAdapter
 
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {
 	switch (arch) {
-		case frame_arch_6502:
-			return std::unique_ptr<TraceAdapter>(new VICETraceAdapter());
-		case frame_arch_arm:
-			return std::unique_ptr<TraceAdapter>(new Arm32TraceAdapter());
-		case frame_arch_aarch64:
-			return std::unique_ptr<TraceAdapter>(new Arm64TraceAdapter());
-		default:
-			return nullptr;
+	case frame_arch_6502:
+		return std::unique_ptr<TraceAdapter>(new VICETraceAdapter());
+	case frame_arch_arm:
+		return std::unique_ptr<TraceAdapter>(new Arm32TraceAdapter());
+	case frame_arch_aarch64:
+		return std::unique_ptr<TraceAdapter>(new Arm64TraceAdapter());
+	default:
+		return nullptr;
 	}
 }

--- a/rz-tracetest/adapter.h
+++ b/rz-tracetest/adapter.h
@@ -15,15 +15,14 @@
 /*
  * Interface for any arch/source/... specific adjustments
  */
-class TraceAdapter
-{
+class TraceAdapter {
 	public:
 		virtual ~TraceAdapter() {}
 
 		/**
 		 * value for asm.arch/analysis.arch
 		 */
-		virtual std::string RizinArch() const =0;
+		virtual std::string RizinArch() const = 0;
 
 		/**
 		 * value for asm.cpu

--- a/rz-tracetest/dump.cpp
+++ b/rz-tracetest/dump.cpp
@@ -62,8 +62,8 @@ static void DumpStdFrame(const std_frame &frame, ut64 index, RzAsm *rzasm, Trace
 	if (frame.has_mode()) {
 		printf("  MODE: %s\n", frame.mode().c_str());
 	}
-	DumpOperandList("  PRE  ", frame.operand_pre_list(), [](const operand_info &, size_t){});
-	DumpOperandList("  POST ", frame.operand_post_list(), [](const operand_info &, size_t){});
+	DumpOperandList("  PRE  ", frame.operand_pre_list(), [](const operand_info &, size_t) {});
+	DumpOperandList("  POST ", frame.operand_post_list(), [](const operand_info &, size_t) {});
 	rz_mem_free(hex);
 }
 

--- a/rz-tracetest/rzemu.cpp
+++ b/rz-tracetest/rzemu.cpp
@@ -5,12 +5,12 @@
 #include "dump.h"
 #include "trace.h"
 
-RizinEmulator::RizinEmulator(std::unique_ptr<TraceAdapter> adapter_arg) :
-		adapter(std::move(adapter_arg)),
-		core(rz_core_new(), rz_core_free),
-		reg(rz_reg_new(), rz_reg_free),
-		vm(nullptr, rz_analysis_il_vm_free),
-		validate_ctx(nullptr, rz_il_validate_global_context_free) {
+RizinEmulator::RizinEmulator(std::unique_ptr<TraceAdapter> adapter_arg)
+    : adapter(std::move(adapter_arg)),
+      core(rz_core_new(), rz_core_free),
+      reg(rz_reg_new(), rz_reg_free),
+      vm(nullptr, rz_analysis_il_vm_free),
+      validate_ctx(nullptr, rz_il_validate_global_context_free) {
 	if (!core) {
 		throw RizinException("Failed to create RzCore.");
 	}
@@ -102,9 +102,9 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 	}
 
 	struct Disasm {
-		bool failed;
-		std::string disasm_str;
-		std::string hex_str;
+			bool failed;
+			std::string disasm_str;
+			std::string hex_str;
 	};
 	std::optional<Disasm> disasm;
 	auto disassemble = [&]() {
@@ -210,7 +210,7 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 	//////////////////////////////////////////
 	// Check manually disassembled op
 
-	std::unique_ptr<RzAnalysisOp, std::function<void (RzAnalysisOp *)>> aop(rz_analysis_op_new(), [](RzAnalysisOp *op) {
+	std::unique_ptr<RzAnalysisOp, std::function<void(RzAnalysisOp *)>> aop(rz_analysis_op_new(), [](RzAnalysisOp *op) {
 		rz_analysis_op_free(op);
 	});
 	if (rz_analysis_op(core->analysis, aop.get(), sf.address(), (const ut8 *)code.data(), code.size(), RZ_ANALYSIS_OP_MASK_ALL) <= 0) {
@@ -395,7 +395,7 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 		bool justified = false;
 		switch (ev->type) {
 		case RZ_IL_EVENT_VAR_READ: {
-			auto check_oplist = [&](const ::google::protobuf::RepeatedPtrField< ::operand_info> & l) {
+			auto check_oplist = [&](const ::google::protobuf::RepeatedPtrField<::operand_info> &l) {
 				for (const auto &o : l) {
 					if (!o.operand_info_specific().has_reg_operand()) {
 						continue;

--- a/rz-tracetest/rzemu.h
+++ b/rz-tracetest/rzemu.h
@@ -14,7 +14,7 @@
 #include <memory>
 #include <optional>
 
-class RizinException: public std::exception {
+class RizinException : public std::exception {
 	public:
 		RizinException(const char *fmt, ...) {
 			va_list ap, ap2;
@@ -32,7 +32,7 @@ class RizinException: public std::exception {
 			delete msg;
 		}
 
-		const char* what() const noexcept override { return msg; }
+		const char *what() const noexcept override { return msg; }
 
 	private:
 		char *msg;


### PR DESCRIPTION
Adds the `.clang-format` file from Rizin.

Only addition is the `IndentAccessModifiers: true` line.