### PR TITLE
Check if missing register should be ignored.

### DIFF
--- a/rz-tracetest/rzemu.cpp
+++ b/rz-tracetest/rzemu.cpp
@@ -184,8 +184,11 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 			}
 			RzRegItem *ri = rz_reg_get(reg.get(), rn.c_str(), RZ_REG_TYPE_ANY);
 			if (!ri) {
-				print_disasm();
+				if (adapter->IgnoreUnknownReg(ro.name())) {
+					continue;
+				}
 				printf("Unknown reg: %s\n", ro.name().c_str());
+				print_disasm();
 				continue;
 			}
 			RzBitVector *bv = rz_bv_new_from_bytes_le((const ut8 *)o.value().data(), 0, RegOperandSizeBits(o));


### PR DESCRIPTION
The ignored registers are not checked at the edited line. If the code is reached it still prints the disassembly and the log message although it should not.