### PR TITLE
Mips Support

### DIFF
--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -273,9 +273,6 @@ class MipsTraceAdapter : public TraceAdapter {
 		}
 
 		int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> machine) const override {
-			// if (mode) {
-			// 	return (mode.value() == FRAME_MODE_MIPS64) ? 64 : 32;
-			// }
 			return machine.value();
 		}
 

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -266,6 +266,28 @@ class I8051TraceAdapter : public TraceAdapter {
 		}
 };
 
+class MipsTraceAdapter : public TraceAdapter {
+	public:
+		std::string RizinArch() const override {
+			return "mips";
+		}
+
+		int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> machine) const override {
+			// if (mode) {
+			// 	return (mode.value() == FRAME_MODE_MIPS64) ? 64 : 32;
+			// }
+			return machine.value();
+		}
+
+		bool IgnorePCMismatch(ut64 pc_actual, ut64 pc_expect) const override {
+			return false;
+		}
+
+		bool IgnoreUnknownReg(const std::string &rz_reg_name) const {
+			return true;
+		}
+};
+
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {
 	switch (arch) {
 	case frame_arch_6502:
@@ -278,6 +300,8 @@ std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {
 		return std::unique_ptr<TraceAdapter>(new PPCTraceAdapter());
 	case frame_arch_8051:
 		return std::unique_ptr<TraceAdapter>(new I8051TraceAdapter());
+	case frame_arch_mips:
+		return std::unique_ptr<TraceAdapter>(new MipsTraceAdapter());
 	default:
 		return nullptr;
 	}


### PR DESCRIPTION
Adds Mips support to rz-tracetest.
- Tracefiles and executables used for testing : [frames.mips32.be](https://transfer.sh/10tQjuSYbi/frames.mips32.be.tar.gz)

- Closing Issues
Closes #11 if merged