### PR TITLE
Add new interface for adjust rz reg contents in some cases

### DIFF
--- a/rz-tracetest/adapter.h
+++ b/rz-tracetest/adapter.h
@@ -59,6 +59,7 @@ class TraceAdapter {
 		 * \param op given only when checking post-operands (otherwise null), to mask out anything op-dependent
 		 */
 		virtual void AdjustRegContentsFromTrace(const std::string &tracename, RzBitVector *trace_val, RzAnalysisOp *op = nullptr) const;
+		virtual void AdjustRegContentsFromTrace(const std::string &tracename, RzBitVector *trace_val, RzBitVector *extra_info, RzAnalysisOp *op = nullptr) const;
 
 		/**
 		 * \brief Edit the contents of a register from RzReg before comparison

--- a/rz-tracetest/rzemu.cpp
+++ b/rz-tracetest/rzemu.cpp
@@ -175,6 +175,7 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 	rz_reg_arena_zero(reg.get(), RZ_REG_TYPE_ANY);
 
 	rz_io_write_at(io, sf.address(), (const ut8 *)code.data(), code.size());
+
 	for (const auto &o : sf.operand_pre_list().elem()) {
 		if (o.operand_info_specific().has_reg_operand()) {
 			const auto &ro = o.operand_info_specific().reg_operand();
@@ -192,7 +193,8 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 				continue;
 			}
 			RzBitVector *bv = rz_bv_new_from_bytes_le((const ut8 *)o.value().data(), 0, RegOperandSizeBits(o));
-			adapter->AdjustRegContentsFromTrace(ro.name(), bv);
+			RzBitVector *extra = rz_reg_get_bv(reg.get(), ri);
+			adapter->AdjustRegContentsFromTrace(ro.name(), bv, extra);
 			if (rz_bv_len(bv) != ri->size) {
 				print_disasm();
 				printf("Can't apply reg value of %s (%s) because its size (%u) is not equal to the one in RzReg (%u)\n",


### PR DESCRIPTION
BAP-qemu frame represent register D17 as two S registers(S34, S35), while those S registers(S32/S33 ...) are not existed in rz_reg for arm32.
`dn` register can be represented as `concat(S_2n, S_2n+1)`, to get the correct d register value I need both two S register value in the for-loop of rz-tracetet
Currently my solution is to modify Adapter interface to support it. It  will affect other architecture's adapters, I am not sure it's a best practice.