### PR TITLE
Rebase 'x86-tracing' onto the latest 'master'

### DIFF
--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -399,6 +399,29 @@ class HexagonTraceAdapter : public TraceAdapter {
 
 };
 
+class X86TraceAdapter : public TraceAdapter {
+	std::string RizinArch() const override {
+		return "x86";
+	}
+
+	std::string RizinCPU() const override {
+		return "x86";
+	}
+
+	int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> machine) const override {
+		if (mode) {
+			return (mode.value() == FRAME_MODE_X86_64) ? 64 : 32;
+		}
+		return machine.value();
+	}
+
+	virtual std::string TraceRegToRizin(const std::string &tracereg) const override {
+		std::string r = tracereg;
+		std::transform(r.begin(), r.end(), r.begin(), ::tolower);
+		return r;
+	}
+};
+
 std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {
 	switch (arch) {
 	case frame_arch_6502:
@@ -417,6 +440,8 @@ std::unique_ptr<TraceAdapter> SelectTraceAdapter(frame_architecture arch) {
 		return std::unique_ptr<TraceAdapter>(new GBTraceAdapter());
 	case frame_arch_hexagon:
 		return std::unique_ptr<TraceAdapter>(new HexagonTraceAdapter());
+	case frame_arch_i386:
+		return std::unique_ptr<TraceAdapter>(new X86TraceAdapter());
 	default:
 		return nullptr;
 	}

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -404,10 +404,6 @@ class X86TraceAdapter : public TraceAdapter {
 		return "x86";
 	}
 
-	std::string RizinCPU() const override {
-		return "x86";
-	}
-
 	int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> machine) const override {
 		return (machine && machine.value() == frame_mach_x86_64) ? 64 : 32;
 	}

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -409,10 +409,7 @@ class X86TraceAdapter : public TraceAdapter {
 	}
 
 	int RizinBits(std::optional<std::string> mode, std::optional<uint64_t> machine) const override {
-		if (mode) {
-			return (mode.value() == FRAME_MODE_X86_64) ? 64 : 32;
-		}
-		return machine.value();
+		return (machine && machine.value() == frame_mach_x86_64) ? 64 : 32;
 	}
 
 	virtual std::string TraceRegToRizin(const std::string &tracereg) const override {

--- a/rz-tracetest/adapter.cpp
+++ b/rz-tracetest/adapter.cpp
@@ -408,6 +408,10 @@ class X86TraceAdapter : public TraceAdapter {
 		return (machine && machine.value() == frame_mach_x86_64) ? 64 : 32;
 	}
 
+	bool IgnorePCMismatch(ut64 pc_actual, ut64 pc_expect) const override {
+		return false;
+	}
+
 	virtual std::string TraceRegToRizin(const std::string &tracereg) const override {
 		std::string r = tracereg;
 		std::transform(r.begin(), r.end(), r.begin(), ::tolower);


### PR DESCRIPTION
This PR rebases 'x86-tracing' onto the latest master branch, preserving all original commits from both branches.

No functional changes were made.