### PR TITLE
Fix a build error by using the correct rizin APIs

### DIFF
--- a/rz-tracetest/rzemu.cpp
+++ b/rz-tracetest/rzemu.cpp
@@ -123,7 +123,7 @@ void RizinEmulator::SetMem(SerializedTrace::TraceContainerReader &trace) {
 		const uint8_t *data = (const ut8 *)sf.rawbytes().data();
 		ut32 size = sf.rawbytes().size();
 		float done = 100.00f * (float)i++ / (float)n;
-		printf("\rTotal frames: %llu Done: %5.2f%% (written: %llu kb)", n, done, total_written / 1000);
+		printf("\rTotal frames: %" PFMT64u " Done: %5.2f%% (written: %" PFMT64u " kb)", n, done, total_written / 1000);
 
 		if (written.count(pc) != 0) {
 			continue;
@@ -178,7 +178,7 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 	const uint32_t code_size = sf.rawbytes().length();
 
 	int need_bits = adapter->RizinBits(sf.has_mode() ? std::make_optional(sf.mode()) : std::nullopt, adapter->GetMachine());
-	if (need_bits && need_bits != core->rasm->bits) {
+	if (need_bits && need_bits != rz_asm_get_bits(core->rasm)) {
 		rz_config_set_i(core->config, "asm.bits", need_bits);
 	}
 
@@ -194,7 +194,7 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 		}
 		disasm = Disasm();
 		RzAsmOp asmop = {};
-		core->rasm->pc = sf.address();
+		rz_asm_set_pc(core->rasm, sf.address());
 		disasm->failed = !code_size || rz_asm_disassemble(core->rasm, &asmop, code_data, code_size) <= 0;
 		if (!disasm->failed) {
 			disasm->disasm_str = rz_strbuf_get(&asmop.buf_asm);
@@ -485,7 +485,7 @@ FrameCheckResult RizinEmulator::RunFrame(ut64 index, frame *f, std::optional<ut6
 			const auto &mo = o.operand_info_specific().mem_operand();
 			ut64 size = MemOperandSizeBytes(o);
 			std::vector<ut8> actual(size);
-			rz_io_read_at(io, mo.address(), actual.data(), size);
+			rz_io_read_at_mapped(io, mo.address(), actual.data(), size);
 			if (memcmp(actual.data(), o.value().data(), size)) {
 				mismatched();
 				char *ts = rz_hex_bin2strdup((const ut8 *)o.value().data(), size);


### PR DESCRIPTION
Currently the master branch fails when trying to build via cmake against the `dev` branch of rizin, errors follows.

```bash

cmake -Bbuild -GNinja
ninja -C build

-- Configuring done (0.1s)
-- Generating done (0.0s)
-- Build files have been written to: /home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/build
ninja: Entering directory `build'
[2/3] Building CXX object CMakeFiles/rz-tracetest.dir/rzemu.cpp.o
FAILED: CMakeFiles/rz-tracetest.dir/rzemu.cpp.o 
/usr/bin/c++  -I/home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/libtrace/../../bap-frames/libtrace/src -I/home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/build/libtrace -isystem /usr/local/include/librz -isystem /usr/local/include/librz/sdb -std=gnu++17 -MD -MT CMakeFiles/rz-tracetest.dir/rzemu.cpp.o -MF CMakeFiles/rz-tracetest.dir/rzemu.cpp.o.d -o CMakeFiles/rz-tracetest.dir/rzemu.cpp.o -c /home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/rzemu.cpp
/home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/rzemu.cpp: In member function ‘void RizinEmulator::SetMem(SerializedTrace::TraceContainerReader&)’:
/home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/rzemu.cpp:126:44: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 2 has type ‘uint64_t’ {aka ‘long unsigned int’} [-Wformat=]
  126 |                 printf("\rTotal frames: %llu Done: %5.2f%% (written: %llu kb)", n, done, total_written / 1000);
      |                                         ~~~^                                    ~
      |                                            |                                    |
      |                                            long long unsigned int               uint64_t {aka long unsigned int}
      |                                         %lu
/home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/rzemu.cpp:126:73: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘uint64_t’ {aka ‘long unsigned int’} [-Wformat=]
  126 |                 printf("\rTotal frames: %llu Done: %5.2f%% (written: %llu kb)", n, done, total_written / 1000);
      |                                                                      ~~~^                ~~~~~~~~~~~~~~~~~~~~
      |                                                                         |                              |
      |                                                                         long long unsigned int         uint64_t {aka long unsigned int}
      |                                                                      %lu
/home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/rzemu.cpp: In member function ‘FrameCheckResult RizinEmulator::RunFrame(uint64_t, frame*, std::optional<long unsigned int>, int, bool, std::optional<std::function<bool(const std::__cxx11::basic_string<char>&)> >, size_t*, bool)’:
/home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/rzemu.cpp:181:49: error: invalid use of incomplete type ‘RzAsm’ {aka ‘struct rz_asm_t’}
  181 |         if (need_bits && need_bits != core->rasm->bits) {
      |                                                 ^~
In file included from /usr/local/include/librz/rz_arch.h:10,
                 from /usr/local/include/librz/rz_core.h:8,
                 from /home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/rzemu.h:9,
                 from /home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/rzemu.cpp:4:
/usr/local/include/librz/rz_asm.h:94:16: note: forward declaration of ‘RzAsm’ {aka ‘struct rz_asm_t’}
   94 | typedef struct rz_asm_t RzAsm;
      |                ^~~~~~~~
/home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/rzemu.cpp: In lambda function:
/home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/rzemu.cpp:197:27: error: invalid use of incomplete type ‘RzAsm’ {aka ‘struct rz_asm_t’}
  197 |                 core->rasm->pc = sf.address();
      |                           ^~
/usr/local/include/librz/rz_asm.h:94:16: note: forward declaration of ‘RzAsm’ {aka ‘struct rz_asm_t’}
   94 | typedef struct rz_asm_t RzAsm;
      |                ^~~~~~~~
/home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/rzemu.cpp: In member function ‘FrameCheckResult RizinEmulator::RunFrame(uint64_t, frame*, std::optional<long unsigned int>, int, bool, std::optional<std::function<bool(const std::__cxx11::basic_string<char>&)> >, size_t*, bool)’:
/home/mostafa/Documents/repos/rz-tracetest/rz-tracetest/rzemu.cpp:488:25: error: ‘rz_io_read_at’ was not declared in this scope; did you mean ‘rz_io_pread_at’?
  488 |                         rz_io_read_at(io, mo.address(), actual.data(), size);
      |                         ^~~~~~~~~~~~~
      |                         rz_io_pread_at
ninja: build stopped: subcommand failed.
```

The changes in this PR fixes this.